### PR TITLE
feat: add webcontent converter function directly

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -5,7 +5,6 @@ import 'package:blue_print_pos/blue_print_pos.dart';
 import 'package:blue_print_pos/models/models.dart';
 import 'package:blue_print_pos/receipt/receipt.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 
 void main() {
@@ -20,7 +19,7 @@ class MyApp extends StatefulWidget {
 class _MyAppState extends State<MyApp> {
   final BluePrintPos _bluePrintPos = BluePrintPos.instance;
   List<BlueDevice> _blueDevices = <BlueDevice>[];
-  BlueDevice _selectedDevice;
+  BlueDevice? _selectedDevice;
   bool _isLoading = false;
   int _loadingAtIndex = -1;
 
@@ -50,8 +49,7 @@ class _MyAppState extends State<MyApp> {
                                 Expanded(
                                   child: GestureDetector(
                                     onTap: _blueDevices[index].address ==
-                                                _selectedDevice?.address ??
-                                            ''
+                                            (_selectedDevice?.address ?? '')
                                         ? _onDisconnectDevice
                                         : () => _onSelectDevice(index),
                                     child: Padding(
@@ -93,16 +91,16 @@ class _MyAppState extends State<MyApp> {
                                   Container(
                                     height: 24.0,
                                     width: 24.0,
-                                    margin: EdgeInsets.only(right: 8.0),
-                                    child: CircularProgressIndicator(
+                                    margin: const EdgeInsets.only(right: 8.0),
+                                    child: const CircularProgressIndicator(
                                       valueColor: AlwaysStoppedAnimation<Color>(
-                                          Colors.blue),
+                                        Colors.blue,
+                                      ),
                                     ),
                                   ),
                                 if (!_isLoading &&
-                                        _blueDevices[index].address ==
-                                            _selectedDevice?.address ??
-                                    '')
+                                    _blueDevices[index].address ==
+                                        (_selectedDevice?.address ?? ''))
                                   TextButton(
                                     onPressed: _onPrintReceipt,
                                     child: Container(
@@ -126,7 +124,7 @@ class _MyAppState extends State<MyApp> {
                                                 .primary
                                                 .withOpacity(0.5);
                                           }
-                                          return null;
+                                          return Theme.of(context).primaryColor;
                                         },
                                       ),
                                     ),
@@ -258,7 +256,8 @@ class _MyAppState extends State<MyApp> {
 
     /// Text after QR
     final ReceiptSectionText receiptSecondText = ReceiptSectionText();
-    receiptSecondText.addText('Powered by ayeee', size: ReceiptTextSizeType.small);
+    receiptSecondText.addText('Powered by ayeee',
+        size: ReceiptTextSizeType.small);
     receiptSecondText.addSpacer();
     await _bluePrintPos.printReceiptText(receiptSecondText, feedCount: 1);
   }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -14,21 +14,21 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.8.1"
   blue_print_pos:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "0.0.4"
+    version: "0.0.5"
   blue_thermal_printer:
     dependency: transitive
     description:
       name: blue_thermal_printer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.1.8"
   boolean_selector:
     dependency: transitive
     description:
@@ -49,7 +49,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -85,27 +85,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.17.0"
-  dio:
-    dependency: transitive
-    description:
-      name: dio
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "4.0.0"
-  easy_logger:
-    dependency: transitive
-    description:
-      name: easy_logger
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.0.2"
   esc_pos_utils_plus:
     dependency: transitive
     description:
       name: esc_pos_utils_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1+3"
+    version: "2.0.1+6"
   fake_async:
     dependency: transitive
     description:
@@ -151,34 +137,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.15.0"
-  http:
-    dependency: transitive
-    description:
-      name: http
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.13.3"
-  http_parser:
-    dependency: transitive
-    description:
-      name: http_parser
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "4.0.0"
   image:
     dependency: transitive
     description:
       name: image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.2"
-  logging:
-    dependency: transitive
-    description:
-      name: logging
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.1"
+    version: "3.0.8"
   matcher:
     dependency: transitive
     description:
@@ -192,7 +157,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
@@ -200,13 +165,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.11.0"
   petitparser:
     dependency: transitive
     description:
@@ -214,24 +172,10 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.1.0"
-  pool:
-    dependency: transitive
-    description:
-      name: pool
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.5.0"
   protobuf:
     dependency: transitive
     description:
       name: protobuf
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.0"
-  puppeteer:
-    dependency: transitive
-    description:
-      name: puppeteer
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.0"
@@ -267,7 +211,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -302,7 +246,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.4.2"
   typed_data:
     dependency: transitive
     description:
@@ -317,13 +261,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
-  webcontent_converter:
-    dependency: transitive
-    description:
-      name: webcontent_converter
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.0.6+2"
   xml:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -8,7 +8,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   blue_print_pos:

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -5,10 +5,9 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
+import 'package:blue_print_pos_example/main.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-import 'package:blue_print_pos_example/main.dart';
 
 void main() {
   testWidgets('Verify Platform version', (WidgetTester tester) async {

--- a/lib/blue_print_pos.dart
+++ b/lib/blue_print_pos.dart
@@ -6,15 +6,13 @@ import 'package:blue_print_pos/models/connection_status.dart';
 import 'package:blue_print_pos/models/models.dart';
 import 'package:blue_print_pos/receipt/receipt_section_text.dart';
 import 'package:blue_print_pos/scanner/blue_scanner.dart';
+import 'package:blue_print_pos/webcontent_converter/webcontent_converter.dart';
+import 'package:blue_thermal_printer/blue_thermal_printer.dart' as blue_thermal;
 import 'package:esc_pos_utils_plus/esc_pos_utils.dart';
 import 'package:flutter_blue/flutter_blue.dart' as flutter_blue;
 import 'package:flutter_blue/gen/flutterblue.pb.dart' as proto;
-import 'package:blue_thermal_printer/blue_thermal_printer.dart' as blue_thermal;
-import 'package:qr_flutter/qr_flutter.dart';
 import 'package:image/image.dart' as img;
-
-// ignore: import_of_legacy_library_into_null_safe
-import 'package:webcontent_converter/webcontent_converter.dart';
+import 'package:qr_flutter/qr_flutter.dart';
 
 class BluePrintPos {
   BluePrintPos._() {

--- a/lib/webcontent_converter/webcontent_converter.dart
+++ b/lib/webcontent_converter/webcontent_converter.dart
@@ -1,0 +1,44 @@
+import 'dart:async';
+import 'dart:developer';
+import 'dart:typed_data';
+import 'package:flutter/services.dart';
+
+/// [WebcontentConverter] will convert into raw bytes image
+class WebcontentConverter {
+  WebcontentConverter._();
+
+  static const MethodChannel _channel = MethodChannel('webcontent_converter');
+
+  /// ## `WebcontentConverter.contentToImage`
+  /// `This method use html content directly to convert html to List<Int> image`
+  /// ### Example:
+  /// ```
+  /// final content = Demo.getReceiptContent();
+  /// var bytes = await WebcontentConverter.contentToImage(content: content);
+  /// if (bytes.length > 0){
+  ///   var dir = await getTemporaryDirectory();
+  ///   var path = join(dir.path, "receipt.jpg");
+  ///   File file = File(path);
+  ///   await file.writeAsBytes(bytes);
+  /// }
+  /// ```
+  static Future<Uint8List> contentToImage({
+    required String content,
+    double duration = 2000,
+    String? executablePath,
+  }) async {
+    final Map<String, dynamic> arguments = <String, dynamic>{
+      'content': content,
+      'duration': duration
+    };
+    Uint8List results = Uint8List.fromList(<int>[]);
+    try {
+      results = await _channel.invokeMethod('contentToImage', arguments) ??
+          Uint8List.fromList(<int>[]);
+    } on Exception catch (e) {
+      log('[method:contentToImage]: $e');
+      throw Exception('Error: $e');
+    }
+    return results;
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -14,14 +14,14 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.8.1"
   blue_thermal_printer:
     dependency: "direct main"
     description:
       name: blue_thermal_printer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.1.8"
   boolean_selector:
     dependency: transitive
     description:
@@ -42,7 +42,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -78,27 +78,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.17.0"
-  dio:
-    dependency: transitive
-    description:
-      name: dio
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "4.0.0"
-  easy_logger:
-    dependency: transitive
-    description:
-      name: easy_logger
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.0.2"
   esc_pos_utils_plus:
     dependency: "direct main"
     description:
       name: esc_pos_utils_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1+3"
+    version: "2.0.1+6"
   fake_async:
     dependency: transitive
     description:
@@ -144,34 +130,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.15.0"
-  http:
-    dependency: transitive
-    description:
-      name: http
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.13.3"
-  http_parser:
-    dependency: transitive
-    description:
-      name: http_parser
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "4.0.0"
   image:
     dependency: "direct main"
     description:
       name: image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.2"
-  logging:
-    dependency: transitive
-    description:
-      name: logging
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.1"
+    version: "3.0.8"
   matcher:
     dependency: transitive
     description:
@@ -185,7 +150,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
@@ -193,13 +158,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.11.0"
   petitparser:
     dependency: transitive
     description:
@@ -207,24 +165,10 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.1.0"
-  pool:
-    dependency: transitive
-    description:
-      name: pool
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.5.0"
   protobuf:
     dependency: transitive
     description:
       name: protobuf
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.0"
-  puppeteer:
-    dependency: transitive
-    description:
-      name: puppeteer
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.0"
@@ -260,7 +204,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -295,7 +239,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.4.2"
   typed_data:
     dependency: transitive
     description:
@@ -310,13 +254,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
-  webcontent_converter:
-    dependency: "direct main"
-    description:
-      name: webcontent_converter
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.0.6+2"
   xml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,6 @@
 name: blue_print_pos
 description: Plugin to connecting bluetooth printer device, support on Android and iOS
 version: 0.0.5
-author: Andri Yoga Nur Pratama<andriyoga.np@gmail.com>
 homepage: https://github.com/andriyoganp/blue_print_pos
 
 environment:
@@ -10,20 +9,18 @@ environment:
 
 dependencies:
   # Handler bluetooth for Android
-  blue_thermal_printer: ^1.1.3
+  blue_thermal_printer: ^1.1.8
   # Utilities for generate ByteBuffer
-  esc_pos_utils_plus: ^2.0.1+3
+  esc_pos_utils_plus: ^2.0.1+6
   # Framewework
   flutter:
     sdk: flutter
   # Handler bluetooth for iOS
   flutter_blue: ^0.8.0
   # Image utilities
-  image: ^3.0.2
+  image: ^3.0.8
   # Generate qr image painter
   qr_flutter: ^4.0.0
-  # Convert image to ByteBuffer
-  webcontent_converter: ^0.0.6+2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Because [webcontent_converter](https://pub.dev/packages/webcontent_converter/install) is still not compatible with nullsafety, so I add manually. To support full build nullsafety for use this package.