### PR TITLE
feat: add option to generate bytes in raster

### DIFF
--- a/lib/blue_print_pos.dart
+++ b/lib/blue_print_pos.dart
@@ -116,6 +116,7 @@ class BluePrintPos {
     ReceiptSectionText receiptSectionText, {
     int feedCount = 0,
     bool useCut = false,
+    bool useRaster = false,
   }) async {
     final Uint8List bytes = await WebcontentConverter.contentToImage(
         content: receiptSectionText.content);
@@ -124,6 +125,7 @@ class BluePrintPos {
       paperSize: PaperSize.mm58,
       feedCount: feedCount,
       useCut: useCut,
+      useRaster: useRaster,
     );
     _printProcess(byteBuffer);
   }
@@ -137,12 +139,14 @@ class BluePrintPos {
     int width = 120,
     int feedCount = 0,
     bool useCut = false,
+    bool useRaster = false,
   }) async {
     final List<int> byteBuffer = await _getBytes(
       bytes,
       customWidth: width,
       feedCount: feedCount,
       useCut: useCut,
+      useRaster: useRaster,
     );
     _printProcess(byteBuffer);
   }

--- a/lib/blue_print_pos.dart
+++ b/lib/blue_print_pos.dart
@@ -211,6 +211,7 @@ class BluePrintPos {
     int customWidth = 0,
     int feedCount = 0,
     bool useCut = false,
+    bool useRaster = false,
   }) async {
     List<int> bytes = <int>[];
     final CapabilityProfile profile = await CapabilityProfile.load();
@@ -219,7 +220,11 @@ class BluePrintPos {
       img.decodeImage(data)!,
       width: customWidth > 0 ? customWidth : paperSize.width,
     );
-    bytes += generator.imageRaster(_resize);
+    if (useRaster) {
+      bytes += generator.imageRaster(_resize);
+    } else {
+      bytes += generator.image(_resize);
+    }
     if (feedCount > 0) {
       bytes += generator.feed(feedCount);
     }


### PR DESCRIPTION
add param options to `useRaster`. When `useRaster` is true, will call method generator, will generate byte to make print an image using (GS v 0) obsolete command. By default will use print an image using (ESC *) command. 